### PR TITLE
Update .travis.yml to use newer Go versions; enhance README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.9.4
-- '1.10'
+- 1.9.5
+- 1.10.1
 sudo: false
 notifications:
   email:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+.DEFAULT_GOAL := test
+
+test:
+	go test -v -covermode=count -coverprofile=profile.out .
+
+build:
+	go build -o pp cmd/pp/
+
+.PHONY: test build

--- a/README.md
+++ b/README.md
@@ -18,12 +18,29 @@
  match. This prevents the password, hashed or not, from leaving the local
  system.
  
+ In effect, this allows you to confirm if your password is seen in one of the
+ many database dumps where passwords were obtained. If your password is not on
+ the list, it does not mean that it is safe or hasn't been compromised. Always
+ remember to never share passwords between different sites or services, as the
+ compromise of one can lead to the compromise of all of your accounts.
+ 
 ## License
 This code is released under the MIT License. Please see the
 [LICENSE](https://github.com/theckman/go-pwnedpasswords/blob/master/LICENSE) for the
 full content of the license.
 
+## Building the Binary
+If you have the Go toolchain installed, you can use the following command to
+install the pwnedpasswords command line client (`pp`):
+
+```Shell
+go get github.com/theckman/go-pwnedpasswords/cmd/pp
+```
+
 ## Usage
+If you plan to use this package as a client library in Go, here is a quick
+example of how to use it:
+
 ```Go
 client, err := pwnedpasswords.New(pwnedpasswords.DefaultURL)
 // handle error


### PR DESCRIPTION
This change updates the `.travis.yml` file to use the latest versions of Go for
testing. In addition, it changes the test invocation to also print out code
coverage percentages.

The `README.md` file was also updated to include more details around what it
means if your password *_isn't_* in the Pwned Passwords DB as well as
instructions around how to install the `pp` command line client.

Signed-off-by: Tim Heckman <t@heckman.io>